### PR TITLE
fixed bug: output.text.replace is not a function

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -390,9 +390,7 @@ export class CognigyClient {
 
 		this.mySocket.on("output", (output: Output) => {
 			if (!this.options.keepMarkup) {
-				try {
-					output.text = (output.text) ? output.text.replace(/<[^>]*>/g, "") : output.text;
-				} catch (err) { }
+			    output.text = (output && output.text && typeof output.text === "string") ? output.text.replace(/<[^>]*>/g, "") : output.text;
 			}
 
 			this.options.handleOutput ? this.options.handleOutput(output) : console.log("Text: " + output.text + " Data: " + output.data);


### PR DESCRIPTION
Added check to see whether output.text exists and if it's a string. Removed try - catch block